### PR TITLE
Remove superfluous configuration from toggle library’s manifest file

### DIFF
--- a/toggle/src/main/AndroidManifest.xml
+++ b/toggle/src/main/AndroidManifest.xml
@@ -1,13 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="cc.soham.toggle">
-
-    <uses-permission android:name="android.permission.INTERNET" />
-
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
 </manifest>


### PR DESCRIPTION
This configuration shouldn't be part of the library's manifest file I believe.